### PR TITLE
Added flag for TLS certificate validation.

### DIFF
--- a/config/sample_xconfwebconfig.conf
+++ b/config/sample_xconfwebconfig.conf
@@ -263,6 +263,7 @@ xconfwebconfig {
     // HTTP CLIENT CERTIFICATES
     // =============================
     http_client {
+        enable_cert_validation = false                        // Enable/disable TLS certificate validation
         ca_comodo_cert_file = "/etc/testpath/test_cert.crt"   // Path to CA certificate file (PEM format)
         cert_file = "/etc/testpath/test.pem"                  // Path to client certificate file (PEM format)
         private_key_file = "/etc/testpath/test_client.pem"    // Path to client private key file (PEM format)

--- a/http/webconfig_server.go
+++ b/http/webconfig_server.go
@@ -97,6 +97,11 @@ type AppMetricsConfig struct {
 }
 
 func NewTlsConfig(conf *configuration.Config) (*tls.Config, error) {
+	certValidationEnabled := conf.GetBoolean("xconfwebconfig.http_client.enable_cert_validation", true)
+	if !certValidationEnabled {
+		log.Warn("TLS certificate validation is disabled by config flag")
+		return nil, nil
+	}
 	certFile := conf.GetString("xconfwebconfig.http_client.ca_comodo_cert_file")
 	if len(certFile) == 0 {
 		return nil, errors.New("xconfwebconfig.http_client.ca_comodo_cert_file not specified")


### PR DESCRIPTION
This update improves the clarity and maintainability of the TLS configuration logic in [webconfig_server.go]

The variable name for the certificate validation flag is now [certValidationEnabled], which clearly indicates its purpose—controlling whether TLS certificate validation is enabled.

The code checks the configuration value xconfwebconfig.http_client.enable_cert_validation (defaulting to true). If certificate validation is disabled, a warning is logged and no TLS configuration is returned, ensuring the application does not attempt to validate certificates when not required.