### PR TITLE
Add account-deleted precook reason and align account mismatch reason logging/tests

### DIFF
--- a/dataapi/feature_control_context.go
+++ b/dataapi/feature_control_context.go
@@ -826,6 +826,8 @@ func generatePrecookDataChangedMetrics(contextMap map[string]string, precookData
 		xhttp.IncreaseAccountIdChangedCounter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
 		if util.IsUnknownValue(precookData.AccountId) || precookData.AccountId == "" {
 			reasons = append(reasons, "account-new")
+		} else if util.IsUnknownValue(contextMap[common.ACCOUNT_ID]) || contextMap[common.ACCOUNT_ID] == "" {
+			reasons = append(reasons, "account-deleted")
 		} else {
 			reasons = append(reasons, "account-mismatched")
 		}

--- a/dataapi/feature_control_context.go
+++ b/dataapi/feature_control_context.go
@@ -796,6 +796,13 @@ func CreatePartnerIdFeature(partnerId string) rfc.Feature {
 	}
 }
 
+func normalizeAccountIDForPrecookReason(accountID string) string {
+	if accountID == "" || util.IsUnknownValue(accountID) {
+		return ""
+	}
+	return accountID
+}
+
 func generatePrecookDataChangedMetrics(contextMap map[string]string, precookData *PreprocessedData, fields log.Fields) []string {
 	tfields := common.FilterLogFields(fields)
 	reasons := []string{}
@@ -821,12 +828,14 @@ func generatePrecookDataChangedMetrics(contextMap map[string]string, precookData
 		reasons = append(reasons, "experience-change")
 	}
 
-	if contextMap[common.ACCOUNT_ID] != precookData.AccountId {
+	currentAccountID := normalizeAccountIDForPrecookReason(contextMap[common.ACCOUNT_ID])
+	precookAccountID := normalizeAccountIDForPrecookReason(precookData.AccountId)
+	if currentAccountID != precookAccountID {
 		log.WithFields(tfields).Debugf("AccountId changed from precook %s to %s", precookData.AccountId, contextMap[common.ACCOUNT_ID])
 		xhttp.IncreaseAccountIdChangedCounter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
-		if util.IsUnknownValue(precookData.AccountId) || precookData.AccountId == "" {
+		if precookAccountID == "" {
 			reasons = append(reasons, "account-new")
-		} else if util.IsUnknownValue(contextMap[common.ACCOUNT_ID]) || contextMap[common.ACCOUNT_ID] == "" {
+		} else if currentAccountID == "" {
 			reasons = append(reasons, "account-deleted")
 		} else {
 			reasons = append(reasons, "account-mismatched")
@@ -855,7 +864,7 @@ func generatePrecookDataChangedIn200Metrics(contextMap map[string]string, precoo
 		xhttp.IncreaseExperienceChangedIn200Counter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
 	}
 
-	if contextMap[common.ACCOUNT_ID] != precookData.AccountId {
+	if normalizeAccountIDForPrecookReason(contextMap[common.ACCOUNT_ID]) != normalizeAccountIDForPrecookReason(precookData.AccountId) {
 		log.WithFields(tfields).Debugf("AccountId changed from precook %s to %s in 200 response", precookData.AccountId, contextMap[common.ACCOUNT_ID])
 		xhttp.IncreaseAccountIdChangedIn200Counter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
 	}

--- a/dataapi/feature_control_context_test.go
+++ b/dataapi/feature_control_context_test.go
@@ -725,3 +725,66 @@ func TestGetAccountInfoFromGrpService_AccountTypePrecedence(t *testing.T) {
 		})
 	}
 }
+
+func TestGeneratePrecookDataChangedMetrics_AccountNew(t *testing.T) {
+	contextMap := map[string]string{
+		common.MODEL:            "MODEL123",
+		common.PARTNER_ID:       "PARTNER1",
+		common.FIRMWARE_VERSION: "1.0.0",
+		common.EXPERIENCE:       "prod",
+		common.ACCOUNT_ID:       "acc-001",
+	}
+	precookData := &PreprocessedData{
+		Model:      "MODEL123",
+		PartnerId:  "PARTNER1",
+		FwVersion:  "1.0.0",
+		Experience: "prod",
+		AccountId:  "",
+	}
+
+	reasons := generatePrecookDataChangedMetrics(contextMap, precookData, log.Fields{})
+
+	assert.Equal(t, []string{"account-new"}, reasons)
+}
+
+func TestGeneratePrecookDataChangedMetrics_AccountDeleted(t *testing.T) {
+	contextMap := map[string]string{
+		common.MODEL:            "MODEL123",
+		common.PARTNER_ID:       "PARTNER1",
+		common.FIRMWARE_VERSION: "1.0.0",
+		common.EXPERIENCE:       "prod",
+		common.ACCOUNT_ID:       "unknown",
+	}
+	precookData := &PreprocessedData{
+		Model:      "MODEL123",
+		PartnerId:  "PARTNER1",
+		FwVersion:  "1.0.0",
+		Experience: "prod",
+		AccountId:  "acc-001",
+	}
+
+	reasons := generatePrecookDataChangedMetrics(contextMap, precookData, log.Fields{})
+
+	assert.Equal(t, []string{"account-deleted"}, reasons)
+}
+
+func TestGeneratePrecookDataChangedMetrics_AccountMismatched(t *testing.T) {
+	contextMap := map[string]string{
+		common.MODEL:            "MODEL123",
+		common.PARTNER_ID:       "PARTNER1",
+		common.FIRMWARE_VERSION: "1.0.0",
+		common.EXPERIENCE:       "prod",
+		common.ACCOUNT_ID:       "acc-002",
+	}
+	precookData := &PreprocessedData{
+		Model:      "MODEL123",
+		PartnerId:  "PARTNER1",
+		FwVersion:  "1.0.0",
+		Experience: "prod",
+		AccountId:  "acc-001",
+	}
+
+	reasons := generatePrecookDataChangedMetrics(contextMap, precookData, log.Fields{})
+
+	assert.Equal(t, []string{"account-mismatched"}, reasons)
+}

--- a/dataapi/feature_control_context_test.go
+++ b/dataapi/feature_control_context_test.go
@@ -788,3 +788,24 @@ func TestGeneratePrecookDataChangedMetrics_AccountMismatched(t *testing.T) {
 
 	assert.Equal(t, []string{"account-mismatched"}, reasons)
 }
+
+func TestGeneratePrecookDataChangedMetrics_AccountUnknownVsNoAccountNoChange(t *testing.T) {
+	contextMap := map[string]string{
+		common.MODEL:            "MODEL123",
+		common.PARTNER_ID:       "PARTNER1",
+		common.FIRMWARE_VERSION: "1.0.0",
+		common.EXPERIENCE:       "prod",
+		common.ACCOUNT_ID:       "NoAccount",
+	}
+	precookData := &PreprocessedData{
+		Model:      "MODEL123",
+		PartnerId:  "PARTNER1",
+		FwVersion:  "1.0.0",
+		Experience: "prod",
+		AccountId:  "unknown",
+	}
+
+	reasons := generatePrecookDataChangedMetrics(contextMap, precookData, log.Fields{})
+
+	assert.Empty(t, reasons)
+}


### PR DESCRIPTION
This pull request improves the logic for detecting account status changes in the `generatePrecookDataChangedMetrics` function and adds comprehensive unit tests to ensure correct behavior for different account scenarios. The main focus is to better distinguish between new, deleted, and mismatched accounts.

Enhancements to account status detection:

* Updated `generatePrecookDataChangedMetrics` in `feature_control_context.go` to add a new condition for detecting when an account has been deleted, appending "account-deleted" to the reasons list.

Testing improvements:

* Added three new unit tests in `feature_control_context_test.go` to verify that the function correctly identifies "account-new", "account-deleted", and "account-mismatched" scenarios.