### PR TITLE
Merge pull request #156 from rdkcentral/shanshan_dev

### DIFF
--- a/dataapi/feature_control_context.go
+++ b/dataapi/feature_control_context.go
@@ -780,54 +780,65 @@ func CreatePartnerIdFeature(partnerId string) rfc.Feature {
 	}
 }
 
-func generatePrecookDataChangedMetrics(contextMap map[string]string, precookData *PreprocessedData, fields log.Fields) {
+func generatePrecookDataChangedMetrics(contextMap map[string]string, precookData *PreprocessedData, fields log.Fields) []string {
 	tfields := common.FilterLogFields(fields)
+	reasons := []string{}
 	if contextMap[common.MODEL] != precookData.Model {
-		log.WithFields(tfields).Infof("Model changed from precook %s to %s", precookData.Model, contextMap[common.MODEL])
+		log.WithFields(tfields).Debugf("Model changed from precook %s to %s", precookData.Model, contextMap[common.MODEL])
 		xhttp.IncreaseModelChangedCounter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
+		reasons = append(reasons, "model-change")
 	}
 	if contextMap[common.PARTNER_ID] != precookData.PartnerId {
-		log.WithFields(tfields).Infof("PartnerId changed from precook %s to %s", precookData.PartnerId, contextMap[common.PARTNER_ID])
+		log.WithFields(tfields).Debugf("PartnerId changed from precook %s to %s", precookData.PartnerId, contextMap[common.PARTNER_ID])
 		xhttp.IncreasePartnerChangedCounter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
+		reasons = append(reasons, "partner-change")
 	}
 	if contextMap[common.FIRMWARE_VERSION] != precookData.FwVersion {
-		log.WithFields(tfields).Infof("FirmwareVersion changed from precook %s to %s", precookData.FwVersion, contextMap[common.FIRMWARE_VERSION])
+		log.WithFields(tfields).Debugf("FirmwareVersion changed from precook %s to %s", precookData.FwVersion, contextMap[common.FIRMWARE_VERSION])
 		xhttp.IncreaseFwVersionChangedCounter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
+		reasons = append(reasons, "firmware-change")
 	}
 
 	if contextMap[common.EXPERIENCE] != precookData.Experience {
-		log.WithFields(tfields).Infof("Experience changed from precook %s to %s", precookData.Experience, contextMap[common.EXPERIENCE])
+		log.WithFields(tfields).Debugf("Experience changed from precook %s to %s", precookData.Experience, contextMap[common.EXPERIENCE])
 		xhttp.IncreaseExperienceChangedCounter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
+		reasons = append(reasons, "experience-change")
 	}
 
 	if contextMap[common.ACCOUNT_ID] != precookData.AccountId {
-		log.WithFields(tfields).Infof("AccountId changed from precook %s to %s", precookData.AccountId, contextMap[common.ACCOUNT_ID])
+		log.WithFields(tfields).Debugf("AccountId changed from precook %s to %s", precookData.AccountId, contextMap[common.ACCOUNT_ID])
 		xhttp.IncreaseAccountIdChangedCounter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
+		if util.IsUnknownValue(precookData.AccountId) || precookData.AccountId == "" {
+			reasons = append(reasons, "account-new")
+		} else {
+			reasons = append(reasons, "account-mismatched")
+		}
 	}
+	return reasons
 }
 
 func generatePrecookDataChangedIn200Metrics(contextMap map[string]string, precookData *PreprocessedData, fields log.Fields) {
 	tfields := common.FilterLogFields(fields)
 	if contextMap[common.MODEL] != precookData.Model {
-		log.WithFields(tfields).Infof("Model changed from precook  %s to %s in 200 response", precookData.Model, contextMap[common.MODEL])
+		log.WithFields(tfields).Debugf("Model changed from precook %s to %s in 200 response", precookData.Model, contextMap[common.MODEL])
 		xhttp.IncreaseModelChangedIn200Counter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
 	}
 	if contextMap[common.PARTNER_ID] != precookData.PartnerId {
-		log.WithFields(tfields).Infof("PartnerId changed from precook %s to %s in 200 response", precookData.PartnerId, contextMap[common.PARTNER_ID])
+		log.WithFields(tfields).Debugf("PartnerId changed from precook %s to %s in 200 response", precookData.PartnerId, contextMap[common.PARTNER_ID])
 		xhttp.IncreasePartnerChangedIn200Counter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
 	}
 	if contextMap[common.FIRMWARE_VERSION] != precookData.FwVersion {
-		log.WithFields(tfields).Infof("FirmwareVersion changed from precook %s to %s in 200 response", precookData.FwVersion, contextMap[common.FIRMWARE_VERSION])
+		log.WithFields(tfields).Debugf("FirmwareVersion changed from precook %s to %s in 200 response", precookData.FwVersion, contextMap[common.FIRMWARE_VERSION])
 		xhttp.IncreaseFwVersionChangedIn200Counter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
 	}
 
 	if contextMap[common.EXPERIENCE] != precookData.Experience {
-		log.WithFields(tfields).Infof("Experience changed from precook %s to %s in 200 response", precookData.Experience, contextMap[common.EXPERIENCE])
+		log.WithFields(tfields).Debugf("Experience changed from precook %s to %s in 200 response", precookData.Experience, contextMap[common.EXPERIENCE])
 		xhttp.IncreaseExperienceChangedIn200Counter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
 	}
 
 	if contextMap[common.ACCOUNT_ID] != precookData.AccountId {
-		log.WithFields(tfields).Infof("AccountId changed fromp precook %s to %s in 200 response", precookData.AccountId, contextMap[common.ACCOUNT_ID])
+		log.WithFields(tfields).Debugf("AccountId changed from precook %s to %s in 200 response", precookData.AccountId, contextMap[common.ACCOUNT_ID])
 		xhttp.IncreaseAccountIdChangedIn200Counter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
 	}
 }

--- a/dataapi/feature_control_handler.go
+++ b/dataapi/feature_control_handler.go
@@ -91,18 +91,24 @@ func GetFeatureControlSettingsHandler(w http.ResponseWriter, r *http.Request) {
 	isRfcPrecookForOfferedFwEnabled := Xc.EnableRfcPrecookForOfferedFw
 	isPrecookLockdownMode := shared.GetBooleanAppSetting(common.PROP_PRECOOK_LOCKDOWN_ENABLED, false)
 	tfields := common.FilterLogFields(fields)
+	ruleEvalReasons := []string{}
 	// only check values of precook flags if not in precook lockdown mode and mac is not in exclusion
 	if isPrecookLockdownMode {
 		log.WithFields(tfields).Debug("Currently in pre-cook lockdown mode, setting pre-cook flags to false.")
+		ruleEvalReasons = append(ruleEvalReasons, "precook-off")
 	} else {
 		exclusionMacsSet, _ := shared.GetGenericNamedListSetByType(shared.MAC_LIST)
 		if exclusionMacsSet.Contains(contextMap[common.ESTB_MAC_ADDRESS]) {
 			log.WithFields(tfields).Debugf("Device mac %s is in precook exclusion list, will not deliver precook data.", contextMap[common.ESTB_MAC_ADDRESS])
 			xhttp.IncreasePrecookExcludeMacListCounter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
+			ruleEvalReasons = append(ruleEvalReasons, "mac-excluded")
 		} else {
 			log.WithFields(tfields).Debug("Currently not in pre-cook lockdown mode and mac not in precook exclusion list, getting current pre-cook flags from config.")
 			canPrecookRfcResponse = canPrecookRfcResponses(tfields)
 			isRfcPrecook304Enabled = Xc.EnableRfcPrecook304
+			if !canPrecookRfcResponse && !isRfcPrecook304Enabled {
+				ruleEvalReasons = append(ruleEvalReasons, "precook-off")
+			}
 		}
 	}
 
@@ -117,7 +123,8 @@ func GetFeatureControlSettingsHandler(w http.ResponseWriter, r *http.Request) {
 		tfields = common.FilterLogFields(fields)
 		if precookData == nil || len(precookData.RfcHash) == 0 {
 			xhttp.IncreaseNoPrecookDataCounter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
-			log.WithFields(tfields).Infof("No precook data found")
+			log.WithFields(tfields).Debug("No precook data found")
+			ruleEvalReasons = append(ruleEvalReasons, "first-contact")
 		} else {
 			ctxHash := precookData.CtxHash
 			var err error
@@ -129,7 +136,8 @@ func GetFeatureControlSettingsHandler(w http.ResponseWriter, r *http.Request) {
 
 			if !contextHashMatched {
 				xhttp.IncreaseCtxHashMismatchCounter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
-				generatePrecookDataChangedMetrics(contextMap, precookData, fields)
+				changeReasons := generatePrecookDataChangedMetrics(contextMap, precookData, fields)
+				ruleEvalReasons = append(ruleEvalReasons, changeReasons...)
 			}
 
 			//check if the incoming ip address is in the same network as the precook data's Ip address based on the subnet mask
@@ -151,6 +159,7 @@ func GetFeatureControlSettingsHandler(w http.ResponseWriter, r *http.Request) {
 			if !ipInSameNetwork {
 				log.WithFields(tfields).Debugf("IP address %s is not in the same network as precook data's IP address %s", contextMap[common.ESTB_IP], precookData.EstbIp)
 				xhttp.IncreaseIpNotInSameNetworkCounter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
+				ruleEvalReasons = append(ruleEvalReasons, "ip-change")
 			}
 
 			if contextMap[common.FIRMWARE_VERSION] == precookData.FwVersion {
@@ -167,19 +176,23 @@ func GetFeatureControlSettingsHandler(w http.ResponseWriter, r *http.Request) {
 				log.WithFields(tfields).Debug("ContextHash match with XDAS's ctxHash, IP addresses are in the same network and FW matched, so delivery precook Data.")
 			} else {
 				log.WithFields(tfields).Debugf("NOT deliver precook data, ContextHashMatched: %v, IP inSameNetwork: %v, isFwVersionMatched: %v, isRfcPrecookForOfferedFwEnabled: %v, isOfferedFwMatched: %v.", contextHashMatched, ipInSameNetwork, isFwVersionMatched, isRfcPrecookForOfferedFwEnabled, isOfferedFwMatched)
+				if contextHashMatched && !isFwVersionMatched && !(isRfcPrecookForOfferedFwEnabled && isOfferedFwMatched) {
+					ruleEvalReasons = append(ruleEvalReasons, "firmware-mismatch")
+				}
 				// disable precook flags
 				canPrecookRfcResponse = false
 				isRfcPrecook304Enabled = false
 			}
 		}
 	}
+	featureControlRuleBase := featurecontrol.NewFeatureControlRuleBase()
+
 	if isRfcPrecook304Enabled {
 		// if configsetHash from device matches precook, return 304 without running rules engine
 		if matchedHash := getMatchedPrecookHash(configSetHash, precookData, isRfcPrecookForOfferedFwEnabled); matchedHash != "" {
-			xhttp.IncreaseReturn304FromPrecookCounter(common.PARTNER_ID, contextMap[common.MODEL])
-			tfields := common.FilterLogFields(fields)
-			tfields["isLiveCalculated"] = false
-			log.WithFields(tfields).Info("Returning 304 based on precook data")
+			xhttp.IncreaseReturn304FromPrecookCounter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
+			fields["ruleEval"] = []string{"precook-304"}
+			fields["isLiveCalculated"] = false
 			headers := map[string]string{
 				common.CONFIG_SET_HASH: matchedHash,
 			}
@@ -194,7 +207,6 @@ func GetFeatureControlSettingsHandler(w http.ResponseWriter, r *http.Request) {
 
 	var precookRulesEngineResponse, precookPostProcessingResponse *[]rfc.FeatureResponse
 	var rfcPostProc string
-	featureControlRuleBase := featurecontrol.NewFeatureControlRuleBase()
 
 	isSecuredConnection := IsSecureConnection(clientProtocolHeader)
 	// return response from XPC precook table if possible
@@ -221,7 +233,7 @@ func GetFeatureControlSettingsHandler(w http.ResponseWriter, r *http.Request) {
 		} else if isRfcPrecookForOfferedFwEnabled && isOfferedFwMatched {
 			fields["configsetHashRulesEngine"] = precookData.OfferedFwRfcRulesEngineHash
 		}
-		log.WithFields(common.FilterLogFields(fields)).Info("Returning precook response")
+		ruleEvalReasons = []string{"precook"}
 		precookResponseList := make([]rfc.FeatureResponse, 0, len(*precookRulesEngineResponse))
 		precookResponseList = append(precookResponseList, *precookRulesEngineResponse...)
 		featureControl.FeatureResponses = precookResponseList
@@ -256,6 +268,13 @@ func GetFeatureControlSettingsHandler(w http.ResponseWriter, r *http.Request) {
 	fields["configsetHashCalculated"] = calculatedConfigSetHash
 
 	isLiveCalculated := precookData == nil || precookRulesEngineResponse == nil
+	if isLiveCalculated {
+		ruleEvalReasons = append(ruleEvalReasons, "live")
+	} else if len(ruleEvalReasons) == 0 {
+		// Only use 'precook' as a fallback if no other reasons (like 'precook-304') were set
+		ruleEvalReasons = []string{"precook"}
+	}
+	fields["ruleEval"] = ruleEvalReasons
 	featureControlRuleBase.LogFeatureInfo(contextMap, appliedFeatureRules, featureControl.FeatureResponses, isLiveCalculated, fields)
 
 	if Ws.Config.GetBoolean("xconfwebconfig.xconf.enable_rfc_penetration_metrics", false) {


### PR DESCRIPTION
This pull request enhances the logging and observability of the precook feature evaluation process in the feature control API. The main improvements are the introduction of a `ruleEvalReasons` array to capture and propagate the reasons for key decision points throughout the request lifecycle, and the adjustment of log levels for less noisy output. These changes will make it easier to debug and analyze why certain feature control decisions were made, especially regarding precook data usage and mismatches.

Key changes:

**Improved Reason Tracking for Rule Evaluation:**
* Introduced a `ruleEvalReasons` slice in `GetFeatureControlSettingsHandler` to accumulate reasons for why precook data is or isn't used (e.g., "precook-off", "mac-excluded", "first-contact", "model-change", "firmware-mismatch", etc.), and propagated this information through the request lifecycle. This array is now included in the logging fields under the `"ruleEval"` key for better observability. [[1]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97R94-R111) [[2]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97L120-R127) [[3]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97L132-R140) [[4]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97R162) [[5]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97R179-R195) [[6]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97R271-R277)

**Metrics and Reason Extraction in Helper Function:**
* Refactored `generatePrecookDataChangedMetrics` to return a list of change reasons (like "model-change", "partner-change", "account-mismatched", etc.) in addition to incrementing metrics, so these can be logged and surfaced to the caller.

**Log Level Adjustments:**
* Changed log messages related to precook data mismatches and absence from `Info` to `Debug` level to reduce log noise and focus attention on more actionable events. [[1]](diffhunk://#diff-710d44b41347ff23c27dfba68c760371e8deb229826b0d5cfb0c5c2506fd0979L783-R841) [[2]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97L120-R127) [[3]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97R162) [[4]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97R179-R195)

**Precook Response Handling:**
* Ensured that when a precook response is returned, the `ruleEvalReasons` is set to `["precook"]` to clearly indicate the path taken, and that fallback reasons are set appropriately depending on the evaluation path. [[1]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97L224-R236) [[2]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97R271-R277)

**Code Clean-up:**
* Moved the instantiation of `featureControlRuleBase` to just before its first use to improve code clarity. [[1]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97R179-R195) [[2]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97L197)

These changes collectively improve the transparency and traceability of feature control decisions, making it easier to diagnose issues and understand system behavior in production.
