### PR TITLE
Cherrypick: Add estbHash field and enhance logging functionality

### DIFF
--- a/common/const_var.go
+++ b/common/const_var.go
@@ -88,6 +88,7 @@ const (
 	ESTB_IP                    = "estbIP"
 	ESTB_MAC_ADDRESS           = "estbMacAddress"
 	ESTB_MAC                   = "eStbMac"
+	ESTB_HASH                  = "estbHash"
 	ECM_MAC_ADDRESS            = "ecmMacAddress"
 	ECM_MAC                    = "eCMMac"
 	ENV                        = "env"

--- a/dataapi/dataapi_common.go
+++ b/dataapi/dataapi_common.go
@@ -27,6 +27,7 @@ import (
 	common "github.com/rdkcentral/xconfwebconfig/common"
 	"github.com/rdkcentral/xconfwebconfig/db"
 	xhttp "github.com/rdkcentral/xconfwebconfig/http"
+	re "github.com/rdkcentral/xconfwebconfig/rulesengine"
 	"github.com/rdkcentral/xconfwebconfig/util"
 
 	log "github.com/sirupsen/logrus"
@@ -115,6 +116,10 @@ func NormalizeCommonContext(contextMap map[string]string, estbMacKey string, ecm
 		normalizedEstbMac, err := util.MacAddrComplexFormat(estbMac)
 		if err == nil {
 			contextMap[estbMacKey] = normalizedEstbMac
+		}
+		// Compute estbHash and store in contextMap
+		if estbHash, ok := re.GetPercentHash(estbMac); ok {
+			contextMap[common.ESTB_HASH] = strconv.FormatFloat(estbHash, 'f', -1, 64)
 		}
 	}
 	ecmMac := contextMap[ecmMacKey]

--- a/dataapi/estb_firmware_context.go
+++ b/dataapi/estb_firmware_context.go
@@ -524,6 +524,8 @@ func DoSplunkLog(contextMap map[string]string, evaluationResult *estbfirmware.Ev
 	if estbMac := contextMap[common.ESTB_MAC]; estbMac != "" {
 		if estbHash, ok := re.GetPercentHash(estbMac); ok {
 			fields[common.ESTB_HASH] = estbHash
+		} else {
+			log.WithFields(common.FilterLogFields(fields)).Debug("Failed to compute estbHash")
 		}
 	}
 	log.WithFields(common.FilterLogFields(fields)).Info("EstbFirmwareService XCONF_LOG")

--- a/dataapi/estb_firmware_context.go
+++ b/dataapi/estb_firmware_context.go
@@ -35,7 +35,6 @@ import (
 	"github.com/rdkcentral/xconfwebconfig/common"
 	"github.com/rdkcentral/xconfwebconfig/db"
 	xhttp "github.com/rdkcentral/xconfwebconfig/http"
-	re "github.com/rdkcentral/xconfwebconfig/rulesengine"
 	coreef "github.com/rdkcentral/xconfwebconfig/shared/estbfirmware"
 	"github.com/rdkcentral/xconfwebconfig/shared/firmware"
 	"github.com/rdkcentral/xconfwebconfig/util"
@@ -520,13 +519,8 @@ func DoSplunkLog(contextMap map[string]string, evaluationResult *estbfirmware.Ev
 			fields["appliedFilters"] = appliedFilters
 		}
 	}
-
-	if estbMac := contextMap[common.ESTB_MAC]; estbMac != "" {
-		if estbHash, ok := re.GetPercentHash(estbMac); ok {
-			fields[common.ESTB_HASH] = estbHash
-		} else {
-			log.WithFields(common.FilterLogFields(fields)).Debug("Failed to compute estbHash")
-		}
+	if estbHash := contextMap[common.ESTB_HASH]; estbHash != "" {
+		fields[common.ESTB_HASH] = estbHash
 	}
 	log.WithFields(common.FilterLogFields(fields)).Info("EstbFirmwareService XCONF_LOG")
 	xhttp.UpdateLogCounter("EstbFirmwareService")

--- a/dataapi/estb_firmware_context.go
+++ b/dataapi/estb_firmware_context.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rdkcentral/xconfwebconfig/common"
 	"github.com/rdkcentral/xconfwebconfig/db"
 	xhttp "github.com/rdkcentral/xconfwebconfig/http"
+	re "github.com/rdkcentral/xconfwebconfig/rulesengine"
 	coreef "github.com/rdkcentral/xconfwebconfig/shared/estbfirmware"
 	"github.com/rdkcentral/xconfwebconfig/shared/firmware"
 	"github.com/rdkcentral/xconfwebconfig/util"
@@ -517,6 +518,12 @@ func DoSplunkLog(contextMap map[string]string, evaluationResult *estbfirmware.Ev
 				appliedFilters = append(appliedFilters, d)
 			}
 			fields["appliedFilters"] = appliedFilters
+		}
+	}
+
+	if estbMac := contextMap[common.ESTB_MAC]; estbMac != "" {
+		if estbHash, ok := re.GetPercentHash(estbMac); ok {
+			fields[common.ESTB_HASH] = estbHash
 		}
 	}
 	log.WithFields(common.FilterLogFields(fields)).Info("EstbFirmwareService XCONF_LOG")

--- a/dataapi/featurecontrol/feature_rule_eval.go
+++ b/dataapi/featurecontrol/feature_rule_eval.go
@@ -147,6 +147,8 @@ func (f *FeatureControlRuleBase) LogFeatureInfo(context map[string]string, appli
 	if estbMac != "" {
 		if estbHash, ok := re.GetPercentHash(estbMac); ok {
 			fields[common.ESTB_HASH] = estbHash
+		} else {
+			log.WithFields(common.FilterLogFields(fields)).Debug("Failed to compute estbHash")
 		}
 	}
 	log.WithFields(common.FilterLogFields(fields)).Info("FeatureControlRuleBase")

--- a/dataapi/featurecontrol/feature_rule_eval.go
+++ b/dataapi/featurecontrol/feature_rule_eval.go
@@ -140,6 +140,15 @@ func (f *FeatureControlRuleBase) LogFeatureInfo(context map[string]string, appli
 	}
 	fields["features"] = featureInstances
 	fields["configSetHash"] = f.CalculateHash(features)
+	estbMac := context[common.ESTB_MAC_ADDRESS]
+	if estbMac == "" {
+		estbMac = context[common.ESTB_MAC]
+	}
+	if estbMac != "" {
+		if estbHash, ok := re.GetPercentHash(estbMac); ok {
+			fields[common.ESTB_HASH] = estbHash
+		}
+	}
 	log.WithFields(common.FilterLogFields(fields)).Info("FeatureControlRuleBase")
 	http.UpdateLogCounter("FeatureControlRuleBase")
 }

--- a/dataapi/featurecontrol/feature_rule_eval.go
+++ b/dataapi/featurecontrol/feature_rule_eval.go
@@ -140,16 +140,8 @@ func (f *FeatureControlRuleBase) LogFeatureInfo(context map[string]string, appli
 	}
 	fields["features"] = featureInstances
 	fields["configSetHash"] = f.CalculateHash(features)
-	estbMac := context[common.ESTB_MAC_ADDRESS]
-	if estbMac == "" {
-		estbMac = context[common.ESTB_MAC]
-	}
-	if estbMac != "" {
-		if estbHash, ok := re.GetPercentHash(estbMac); ok {
-			fields[common.ESTB_HASH] = estbHash
-		} else {
-			log.WithFields(common.FilterLogFields(fields)).Debug("Failed to compute estbHash")
-		}
+	if estbHash := context[common.ESTB_HASH]; estbHash != "" {
+		fields[common.ESTB_HASH] = estbHash
 	}
 	log.WithFields(common.FilterLogFields(fields)).Info("FeatureControlRuleBase")
 	http.UpdateLogCounter("FeatureControlRuleBase")

--- a/rulesengine/rule_utils.go
+++ b/rulesengine/rule_utils.go
@@ -55,7 +55,7 @@ func contains(carray []conditionCount, cond Condition) int {
 	return -1
 }
 
-func FitsPercent(itf interface{}, percent float64) bool {
+func hashCodeFromValue(itf interface{}) (float64, bool) {
 	var bbytes []byte
 
 	switch ty := itf.(type) {
@@ -65,10 +65,28 @@ func FitsPercent(itf interface{}, percent float64) bool {
 		bbytes = make([]byte, 8)
 		binary.LittleEndian.PutUint64(bbytes, uint64(ty))
 	default:
-		return false
+		return 0, false
 	}
 
 	hashCode := float64(int64(siphash.Sum64(bbytes, &SipHashKey))) + voffset
+	return hashCode, true
+}
+
+func GetPercentHash(itf interface{}) (float64, bool) {
+	hashCode, ok := hashCodeFromValue(itf)
+	if !ok {
+		return 0, false
+	}
+
+	return (hashCode / vrange) * 100, true
+}
+
+func FitsPercent(itf interface{}, percent float64) bool {
+	hashCode, ok := hashCodeFromValue(itf)
+	if !ok {
+		return false
+	}
+
 	limit := percent / 100 * vrange
 	return hashCode <= limit
 }

--- a/rulesengine/rule_utils_test.go
+++ b/rulesengine/rule_utils_test.go
@@ -38,6 +38,23 @@ func TestFitsPercent(t *testing.T) {
 	assert.Assert(t, !isFit)
 }
 
+func TestGetPercentHash(t *testing.T) {
+	// Regression check: this MAC address is expected to hash to approximately 22.1976%.
+	// Use a small tolerance instead of a broad magic-number range so the expectation is explicit.
+	const expectedHash = 22.1976
+	const tolerance = 0.01
+
+	hash, ok := GetPercentHash("7A:86:0A:C2:6D:7B")
+	assert.Assert(t, ok)
+	assert.Assert(t, hash >= 0.0 && hash <= 100.0)
+	assert.Assert(t, hash >= expectedHash-tolerance && hash <= expectedHash+tolerance)
+}
+
+func TestGetPercentHashInvalidType(t *testing.T) {
+	_, ok := GetPercentHash(true)
+	assert.Assert(t, !ok)
+}
+
 func TestFitsStartAndEndPercent1(t *testing.T) {
 	cpeMac := "C2:4B:03:3C:8D:8C" // 84.9997%
 	isFit1 := FitsPercent(cpeMac, float64(50))


### PR DESCRIPTION
## Summary
Adds support for computing and logging estbHash (percent hash derived from ESTB MAC) across XCONF logging and rule evaluation flows.

## Changes
- Introduced new constant estbHash in common constants.
- Extended NormalizeCommonContext to compute estbHash from ESTB MAC and include it in the request context.
- Added estbHash to structured logs:
  - EstbFirmwareService XCONF_LOG
  - FeatureControlRuleBase
- Refactored rules engine hashing logic:
  - Extracted reusable hashCodeFromValue
  - Introduced GetPercentHash for normalized percentage computation
  - Updated FitsPercent to reuse shared hashing logic
- Added unit tests for GetPercentHash (valid + invalid cases) to ensure deterministic hashing behavior.

## Impact
- Enables visibility into ESTB percentage bucketing via logs.
- Improves consistency and reuse of hashing logic in rules engine.
- No functional change to existing rule evaluation behavior beyond added observability.