### PR TITLE
Refactor rule evaluation handling and add utility function for formatting rule evaluation status

### DIFF
--- a/dataapi/feature_control_handler.go
+++ b/dataapi/feature_control_handler.go
@@ -191,7 +191,7 @@ func GetFeatureControlSettingsHandler(w http.ResponseWriter, r *http.Request) {
 		// if configsetHash from device matches precook, return 304 without running rules engine
 		if matchedHash := getMatchedPrecookHash(configSetHash, precookData, isRfcPrecookForOfferedFwEnabled); matchedHash != "" {
 			xhttp.IncreaseReturn304FromPrecookCounter(contextMap[common.PARTNER_ID], contextMap[common.MODEL])
-			fields["ruleEval"] = []string{"precook-304"}
+			fields["ruleEval"] = "precook-304"
 			fields["isLiveCalculated"] = false
 			headers := map[string]string{
 				common.CONFIG_SET_HASH: matchedHash,
@@ -274,7 +274,7 @@ func GetFeatureControlSettingsHandler(w http.ResponseWriter, r *http.Request) {
 		// Only use 'precook' as a fallback if no other reasons (like 'precook-304') were set
 		ruleEvalReasons = []string{"precook"}
 	}
-	fields["ruleEval"] = ruleEvalReasons
+	fields["ruleEval"] = util.FormatRuleEvalStatus(ruleEvalReasons)
 	featureControlRuleBase.LogFeatureInfo(contextMap, appliedFeatureRules, featureControl.FeatureResponses, isLiveCalculated, fields)
 
 	if Ws.Config.GetBoolean("xconfwebconfig.xconf.enable_rfc_penetration_metrics", false) {

--- a/util/string.go
+++ b/util/string.go
@@ -232,9 +232,6 @@ func IsBlank(str string) bool {
 }
 
 func FormatRuleEvalStatus(ruleEvalReasons []string) string {
-	if len(ruleEvalReasons) == 1 {
-		return ruleEvalReasons[0]
-	}
 	return strings.Join(ruleEvalReasons, "-")
 }
 

--- a/util/string.go
+++ b/util/string.go
@@ -231,6 +231,13 @@ func IsBlank(str string) bool {
 	return strings.Trim(str, " ") == ""
 }
 
+func FormatRuleEvalStatus(ruleEvalReasons []string) string {
+	if len(ruleEvalReasons) == 1 {
+		return ruleEvalReasons[0]
+	}
+	return strings.Join(ruleEvalReasons, "-")
+}
+
 func StringSliceEqual(a, b []string) bool {
 	// If one is nil, the other must also be nil.
 	if (a == nil) != (b == nil) {

--- a/util/string_test.go
+++ b/util/string_test.go
@@ -300,7 +300,20 @@ func TestNormalizeMacAddress(t *testing.T) {
 	result = NormalizeMacAddress("")
 	assert.Equal(t, result, "") // Should return original if empty
 }
+func TestFormatRuleEvalStatus(t *testing.T) {
+	// Test with empty reasons
+	result := FormatRuleEvalStatus([]string{})
+	assert.Equal(t, result, "")
 
+	// Test with one reason
+	result = FormatRuleEvalStatus([]string{"precook"})
+	assert.Equal(t, result, "precook")
+
+	// Test with multiple reasons
+	result = FormatRuleEvalStatus([]string{"precook", "live"})
+	assert.Equal(t, result, "precook-live")
+
+}
 func TestStringSliceEqual(t *testing.T) {
 	// Test equal slices
 	slice1 := []string{"a", "b", "c"}


### PR DESCRIPTION
This pull request refactors how the `ruleEval` field is handled in the feature control handler by standardizing its format. Instead of sometimes storing a string and sometimes a string slice, a new utility function ensures `ruleEval` is always a formatted string. This improves consistency and simplifies downstream processing.

**Refactoring and Consistency Improvements:**

* Introduced `util.FormatRuleEvalStatus`, a utility function to consistently format `ruleEval` as a string, joining multiple reasons with a dash if necessary (`util/string.go`).
* Updated assignments to the `fields["ruleEval"]` field in `GetFeatureControlSettingsHandler` to use the new formatting function, ensuring `ruleEval` is always a string rather than sometimes a slice (`dataapi/feature_control_handler.go`). [[1]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97L194-R194) [[2]](diffhunk://#diff-7f30d83d14c56846765c3e856d7a7625cd76895d753a193fae92783e337a7f97L277-R277)