### PR TITLE
Rename FormatRuleEvalStatus to FormatRuleEvalReasons and update logic to handle empty input

### DIFF
--- a/dataapi/feature_control_handler.go
+++ b/dataapi/feature_control_handler.go
@@ -274,7 +274,7 @@ func GetFeatureControlSettingsHandler(w http.ResponseWriter, r *http.Request) {
 		// Only use 'precook' as a fallback if no other reasons (like 'precook-304') were set
 		ruleEvalReasons = []string{"precook"}
 	}
-	fields["ruleEval"] = util.FormatRuleEvalStatus(ruleEvalReasons)
+	fields["ruleEval"] = util.FormatRuleEvalReasons(ruleEvalReasons)
 	featureControlRuleBase.LogFeatureInfo(contextMap, appliedFeatureRules, featureControl.FeatureResponses, isLiveCalculated, fields)
 
 	if Ws.Config.GetBoolean("xconfwebconfig.xconf.enable_rfc_penetration_metrics", false) {

--- a/util/string.go
+++ b/util/string.go
@@ -231,7 +231,10 @@ func IsBlank(str string) bool {
 	return strings.Trim(str, " ") == ""
 }
 
-func FormatRuleEvalStatus(ruleEvalReasons []string) string {
+func FormatRuleEvalReasons(ruleEvalReasons []string) string {
+	if len(ruleEvalReasons) == 0 {
+		return "unknown"
+	}
 	return strings.Join(ruleEvalReasons, "-")
 }
 

--- a/util/string_test.go
+++ b/util/string_test.go
@@ -300,7 +300,7 @@ func TestNormalizeMacAddress(t *testing.T) {
 	result = NormalizeMacAddress("")
 	assert.Equal(t, result, "") // Should return original if empty
 }
-func TestFormatRuleEvalStatus(t *testing.T) {
+func TestFormatRuleEvalReasons(t *testing.T) {
 	// Test with empty reasons
 	result := FormatRuleEvalReasons([]string{})
 	assert.Equal(t, result, "unknown")

--- a/util/string_test.go
+++ b/util/string_test.go
@@ -302,17 +302,16 @@ func TestNormalizeMacAddress(t *testing.T) {
 }
 func TestFormatRuleEvalStatus(t *testing.T) {
 	// Test with empty reasons
-	result := FormatRuleEvalStatus([]string{})
-	assert.Equal(t, result, "")
+	result := FormatRuleEvalReasons([]string{})
+	assert.Equal(t, result, "unknown")
 
 	// Test with one reason
-	result = FormatRuleEvalStatus([]string{"precook"})
+	result = FormatRuleEvalReasons([]string{"precook"})
 	assert.Equal(t, result, "precook")
 
 	// Test with multiple reasons
-	result = FormatRuleEvalStatus([]string{"precook", "live"})
+	result = FormatRuleEvalReasons([]string{"precook", "live"})
 	assert.Equal(t, result, "precook-live")
-
 }
 func TestStringSliceEqual(t *testing.T) {
 	// Test equal slices


### PR DESCRIPTION
This pull request updates how rule evaluation reasons are formatted and handled in the codebase. The main change is the renaming and enhancement of the formatting function to handle empty input more explicitly, which also affects related usages and tests.

**Enhancements to rule evaluation formatting:**

* Renamed the function `FormatRuleEvalStatus` to `FormatRuleEvalReasons` and updated its logic to return `"unknown"` when the input slice is empty, instead of an empty string.
* Updated all usages in `feature_control_handler.go` to use the new function name `FormatRuleEvalReasons`.

**Test updates:**

* Updated the test in `string_test.go` to check for the new behavior: expecting `"unknown"` for empty input, and ensuring the new function name is used throughout the test cases.