### PR TITLE
Merge pull request #177 from rdkcentral/feature/rfcLog_enhancement

### DIFF
--- a/dataapi/feature_control_handler.go
+++ b/dataapi/feature_control_handler.go
@@ -274,7 +274,7 @@ func GetFeatureControlSettingsHandler(w http.ResponseWriter, r *http.Request) {
 		// Only use 'precook' as a fallback if no other reasons (like 'precook-304') were set
 		ruleEvalReasons = []string{"precook"}
 	}
-	fields["ruleEval"] = ruleEvalReasons
+	fields["ruleEval"] = util.FormatRuleEvalReasons(ruleEvalReasons)
 	featureControlRuleBase.LogFeatureInfo(contextMap, appliedFeatureRules, featureControl.FeatureResponses, isLiveCalculated, fields)
 
 	if Ws.Config.GetBoolean("xconfwebconfig.xconf.enable_rfc_penetration_metrics", false) {

--- a/util/string.go
+++ b/util/string.go
@@ -231,6 +231,13 @@ func IsBlank(str string) bool {
 	return strings.Trim(str, " ") == ""
 }
 
+func FormatRuleEvalReasons(ruleEvalReasons []string) string {
+	if len(ruleEvalReasons) == 0 {
+		return "unknown"
+	}
+	return strings.Join(ruleEvalReasons, "-")
+}
+
 func StringSliceEqual(a, b []string) bool {
 	// If one is nil, the other must also be nil.
 	if (a == nil) != (b == nil) {

--- a/util/string_test.go
+++ b/util/string_test.go
@@ -300,7 +300,19 @@ func TestNormalizeMacAddress(t *testing.T) {
 	result = NormalizeMacAddress("")
 	assert.Equal(t, result, "") // Should return original if empty
 }
+func TestFormatRuleEvalReasons(t *testing.T) {
+	// Test with empty reasons
+	result := FormatRuleEvalReasons([]string{})
+	assert.Equal(t, result, "unknown")
 
+	// Test with one reason
+	result = FormatRuleEvalReasons([]string{"precook"})
+	assert.Equal(t, result, "precook")
+
+	// Test with multiple reasons
+	result = FormatRuleEvalReasons([]string{"precook", "live"})
+	assert.Equal(t, result, "precook-live")
+}
 func TestStringSliceEqual(t *testing.T) {
 	// Test equal slices
 	slice1 := []string{"a", "b", "c"}


### PR DESCRIPTION
Rename FormatRuleEvalStatus to FormatRuleEvalReasons and update logic to handle empty input